### PR TITLE
Fix dm transition destination of profile to message

### DIFF
--- a/Packages/BeMatch/Sources/DirectMessageTabFeature/DirectMessageTab.swift
+++ b/Packages/BeMatch/Sources/DirectMessageTabFeature/DirectMessageTab.swift
@@ -100,7 +100,7 @@ public struct DirectMessageTabLogic {
         let explorerState = ProfileExplorerLogic.State(
           username: username,
           targetUserId: targetUserId,
-          tab: ProfileExplorerLogic.Tab.profile
+          tab: ProfileExplorerLogic.Tab.message
         )
         state.destination = Destination.State.explorer(explorerState)
         return .run { _ in


### PR DESCRIPTION
- https://one-hello.slack.com/archives/C068ULSCB38/p1712075643208289
- DMタブのマッチ一覧カルーセルからユーザーをタップした際の遷移先をprofileからmessagesにする